### PR TITLE
Adding golang http handle functions for sigin, welcome and refresh.

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ func main() {
 	http.HandleFunc("/history", server.GroupHistory)
 	http.HandleFunc("/user", server.ShowUser)
 	http.HandleFunc("/message", server.CreateNewMessage) // @TODO - make it only available to POST
+	http.HandleFunc("/signin", server.Signin)
+	http.HandleFunc("/welcome", server.Welcome)
+	http.HandleFunc("/refresh", server.Refresh)
 	// server.SetupRouter()
 
 	//start listening for incoming chat messages

--- a/processing/server.go
+++ b/processing/server.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"github.com/dgrijalva/jwt-go"
+	"time"
 
 	pg "../postgres"
 
@@ -13,6 +15,27 @@ import (
 	//"github.com/gorilla/mux"
 	//"github.com/gorilla/websocket"
 )
+
+// Create the JWT key used to create the signature
+var jwtKey = []byte("my_secret_key")
+
+var users = map[string]string{
+	"user1": "password1",
+	"user2": "password2",
+}
+
+// Create a struct to read the username and password from the request body
+type Credentials struct {
+	Password string `json:"password"`
+	Username string `json:"username"`
+}
+
+// Create a struct that will be encoded to a JWT.
+// We add jwt.StandardClaims as an embedded type, to provide fields like expiry time
+type Claims struct {
+	Username string `json:"username"`
+	jwt.StandardClaims
+}
 
 var clients = make(map[*websocket.Conn]bool) //connected clients
 var broadcast = make(chan MessageTest)       //broadcast channel
@@ -42,8 +65,12 @@ func SetupRouting() {
 
 	http.HandleFunc("/message", CreateNewMessage)
 
+	http.HandleFunc("/signin", Signin)
+
 	// message routing
 	http.HandleFunc("/messages", MessageHandler)
+	http.HandleFunc("/welcome", Welcome)
+	http.HandleFunc("/refresh", Refresh)
 }
 
 func HandleConnections(w http.ResponseWriter, r *http.Request) {
@@ -161,6 +188,7 @@ func GroupHistory(w http.ResponseWriter, r *http.Request) {
 }
 
 func CreateNewMessage(w http.ResponseWriter, r *http.Request) {
+	log.Println("creating new message")
 	AddCors(&w)
 	decoder := json.NewDecoder(r.Body)
 	var t MessageTest
@@ -186,6 +214,166 @@ func CreateNewMessage(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("%s", sample)
 	fmt.Printf("%s", pagesJSON)
+}
+
+// Create the Signin handler
+func Signin(w http.ResponseWriter, r *http.Request) {
+	AddCors(&w)
+	fmt.Printf("got here lul")
+	log.Println("omegalul")
+	var creds Credentials
+	// Get the JSON body and decode into credentials
+	err := json.NewDecoder(r.Body).Decode(&creds)
+	if err != nil {
+		// If the structure of the body is wrong, return an HTTP error
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Get the expected password from our in memory map
+	expectedPassword, ok := users[creds.Username]
+
+	// If a password exists for the given user
+	// AND, if it is the same as the password we received, the we can move ahead
+	// if NOT, then we return an "Unauthorized" status
+	if !ok || expectedPassword != creds.Password {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	// Declare the expiration time of the token
+	// here, we have kept it as 5 minutes
+	expirationTime := time.Now().Add(1 * time.Minute)
+	// Create the JWT claims, which includes the username and expiry time
+	claims := &Claims{
+		Username: creds.Username,
+		StandardClaims: jwt.StandardClaims{
+			// In JWT, the expiry time is expressed as unix milliseconds
+			ExpiresAt: expirationTime.Unix(),
+		},
+	}
+
+	// Declare the token with the algorithm used for signing, and the claims
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	// Create the JWT string
+	tokenString, err := token.SignedString(jwtKey)
+	if err != nil {
+		// If there is an error in creating the JWT return an internal server error
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Finally, we set the client cookie for "token" as the JWT we just generated
+	// we also set an expiry time which is the same as the token itself
+	http.SetCookie(w, &http.Cookie{
+		Name:    "token",
+		Value:   tokenString,
+		Expires: expirationTime,
+	})
+}
+
+func Welcome(w http.ResponseWriter, r *http.Request) {
+	AddCors(&w)
+	// We can obtain the session token from the requests cookies, which come with every request
+	c, err := r.Cookie("token")
+	if err != nil {
+		if err == http.ErrNoCookie {
+			// If the cookie is not set, return an unauthorized status
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// For any other type of error, return a bad request status
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Get the JWT string from the cookie
+	tknStr := c.Value
+
+	// Initialize a new instance of `Claims`
+	claims := &Claims{}
+
+	// Parse the JWT string and store the result in `claims`.
+	// Note that we are passing the key in this method as well. This method will return an error
+	// if the token is invalid (if it has expired according to the expiry time we set on sign in),
+	// or if the signature does not match
+	tkn, err := jwt.ParseWithClaims(tknStr, claims, func(token *jwt.Token) (interface{}, error) {
+		return jwtKey, nil
+	})
+	if err != nil {
+		if err == jwt.ErrSignatureInvalid {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if !tkn.Valid {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	// Finally, return the welcome message to the user, along with their
+	// username given in the token
+	w.Write([]byte(fmt.Sprintf("Welcome %s!", claims.Username)))
+}
+
+func Refresh(w http.ResponseWriter, r *http.Request) {
+	AddCors(&w)
+
+	// (BEGIN) The code uptil this point is the same as the first part of the `Welcome` route
+	c, err := r.Cookie("token")
+	if err != nil {
+		if err == http.ErrNoCookie {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	tknStr := c.Value
+	claims := &Claims{}
+	tkn, err := jwt.ParseWithClaims(tknStr, claims, func(token *jwt.Token) (interface{}, error) {
+		return jwtKey, nil
+	})
+	if !tkn.Valid {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	if err != nil {
+		if err == jwt.ErrSignatureInvalid {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	// (END) The code up-till this point is the same as the first part of the `Welcome` route
+
+	// We ensure that a new token is not issued until enough time has elapsed
+	// In this case, a new token will only be issued if the old token is within
+	// 30 seconds of expiry. Otherwise, return a bad request status
+	if time.Unix(claims.ExpiresAt, 0).Sub(time.Now()) > 30*time.Second {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Now, create a new token for the current use, with a renewed expiration time
+	expirationTime := time.Now().Add(5 * time.Minute)
+	claims.ExpiresAt = expirationTime.Unix()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(jwtKey)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Set the new token as the users `token` cookie
+	http.SetCookie(w, &http.Cookie{
+		Name:    "token",
+		Value:   tokenString,
+		Expires: expirationTime,
+	})
 }
 
 func MessageHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
To test with postman:


`POST http://localhost:8000/signin`
{"username":"user1","password":"password1"}


You can now try hitting the welcome route from the same client to get the welcome message:
`GET http://localhost:8000/welcome`

Hit the refresh route, and then inspect the clients cookies to see the new value of the token cookie:
`POST http://localhost:8000/refresh`